### PR TITLE
Avoid unnecessary call to getMockModule

### DIFF
--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -31,7 +31,9 @@ export type ValueType =
   | 'undefined';
 
 const EXPECTED_COLOR = chalk.green;
+const EXPECTED_BG = chalk.bgGreen;
 const RECEIVED_COLOR = chalk.red;
+const RECEIVED_BG = chalk.bgRed;
 
 const NUMBERS = [
   'zero',
@@ -110,8 +112,17 @@ const stringify = (object: any, maxDepth?: number = 10): string => {
     : result;
 };
 
-const printReceived = (object: any) => RECEIVED_COLOR(stringify(object));
-const printExpected = (value: any) => EXPECTED_COLOR(stringify(value));
+const highlightTrailingWhitespace = (text: string, bgColor: Function): string =>
+  text.replace(/\s+$/gm, bgColor('$&'));
+
+const printReceived = (object: any) => highlightTrailingWhitespace(
+  RECEIVED_COLOR(stringify(object)),
+  RECEIVED_BG,
+);
+const printExpected = (value: any) => highlightTrailingWhitespace(
+  EXPECTED_COLOR(stringify(value)),
+  EXPECTED_BG,
+);
 
 const printWithType = (
   name: string,
@@ -192,13 +203,16 @@ const matcherHint = (
 };
 
 module.exports = {
+  EXPECTED_BG,
   EXPECTED_COLOR,
+  RECEIVED_BG,
   RECEIVED_COLOR,
   ensureActualIsNumber,
   ensureExpectedIsNumber,
   ensureNoExpected,
   ensureNumbers,
   getType,
+  highlightTrailingWhitespace,
   matcherHint,
   pluralize,
   printExpected,

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -19,8 +19,10 @@ const {
   separateMessageFromStack,
 } = require('jest-util');
 const {
+  RECEIVED_BG,
   RECEIVED_COLOR,
   getType,
+  highlightTrailingWhitespace,
   matcherHint,
   printExpected,
   printWithType,
@@ -149,7 +151,9 @@ const printActualErrorMessage = error => {
     return (
       `Instead, it threw:\n` +
       RECEIVED_COLOR(
-        '  ' + message + formatStackTrace(stack, {
+        '  ' +
+        highlightTrailingWhitespace(message, RECEIVED_BG) +
+        formatStackTrace(stack, {
           noStackTrace: false,
           rootDir: process.cwd(),
           testRegex: '',

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -586,11 +586,11 @@ class Runtime {
       return this._shouldMockModuleCache[moduleID];
     }
 
-    const manualMock = this._resolver.getMockModule(from, moduleName);
     let modulePath;
     try {
       modulePath = this._resolveModule(from, moduleName);
     } catch (e) {
+      const manualMock = this._resolver.getMockModule(from, moduleName);
       if (manualMock) {
         this._shouldMockModuleCache[moduleID] = true;
         return true;


### PR DESCRIPTION
**Summary**

`getMockModule` is called even when it is not used. After this patch `yarn test` is running ~2 seconds faster in my computer. I am not familiar with the code to estimate the impact, but it worth to be fixed anyway.

**Test plan**

`yarn test`


Before:
<img width="1436" alt="screen shot 2017-01-22 at 10 33 18 pm" src="https://cloud.githubusercontent.com/assets/88476/22193930/dafe3d22-e0f3-11e6-881b-c5181c380494.png">

After:
<img width="1436" alt="screen shot 2017-01-22 at 10 35 32 pm" src="https://cloud.githubusercontent.com/assets/88476/22193933/e121a8d8-e0f3-11e6-95ee-d01aeb0e1907.png">

